### PR TITLE
[CHORE] : Redis 연결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  redis:
+    image: redis:latest
+    container_name: redis-server
+    ports:
+      - "6379:6379"
+    networks:
+      - redis-network
+    volumes:
+      - redis-data:/data
+    restart: always
+
+networks:
+  redis-network:
+    driver: bridge
+
+volumes:
+  redis-data:
+    driver: local

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=notification-service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  application:
+    name: notification-service
+  data:
+    redis:
+      port: 6379
+      host: localhost


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
closes #2 
  <br/>

## 🔎 작업 내용
- Redis 컨테이너 생성 (docker compose)
- Redis 연결 정보 추가 (yml)
- Redis 연결 상태 확인 (actuator)
  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->
Redis 컨테이너 포트번호가 6379로 하드 코딩되어있는데 실제 배포환경에서는 환경변수 처리 필요할 듯 합니다. 그때에는 포트번호도 범용적으로 사용되는 6379보다는 63790과 같은 다른 포트번호를 사용하는 것도 좋아보입니다.
  <br/>

## 📈이미지 첨부 (필요시)
<img width="196" alt="스크린샷 2025-04-27 오후 10 03 50" src="https://github.com/user-attachments/assets/8b78db67-b478-422d-bcf6-6b0b3342ec5d" />

  <br/>