### PR TITLE
[FEAT] Redis Pub/Sub 기반 알림 발행 기능 구현

### DIFF
--- a/src/main/java/com/mysite/notificationservice/domain/notification/publisher/NotificationPublisher.java
+++ b/src/main/java/com/mysite/notificationservice/domain/notification/publisher/NotificationPublisher.java
@@ -1,0 +1,34 @@
+package com.mysite.notificationservice.domain.notification.publisher;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * PackageName : com.mysite.notificationservice.domain.notification.publisher
+ * FileName    : NotificationPublisher
+ * Author      : hc
+ * Date        : 25. 4. 28.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 25. 4. 28.     hc               Initial creation
+ */
+@Component
+public class NotificationPublisher {
+
+	private static final String CHANNEL_NAME = "notification";
+	private final StringRedisTemplate redisTemplate;
+
+	@Autowired
+	public NotificationPublisher(StringRedisTemplate redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+
+	public void publish(String userId, String message) {
+		// 예: "userId|message" 형태로 보내기
+		String payload = userId + "|" + message;
+		redisTemplate.convertAndSend(CHANNEL_NAME, payload);
+	}
+}


### PR DESCRIPTION
- NotificationPublisher 생성
- Redis를 통해 특정 채널(notification)로 사용자 ID와 알림 내용을 발행
- payload 형식: "userId|message" (추후 JSON 포맷으로 확장 가능)

<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
closes #4 
  <br/>

## 🔎 작업 내용
- NotificationPublisher 생성
- Redis를 통해 특정 채널(notification)로 사용자 ID와 알림 내용을 발행
- payload 형식: "userId|message" (추후 JSON 포맷으로 확장 가능)

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>