### PR TITLE
[FEAT] Redis Subscriber 구현 및 SSE 알림 전송 기능 추가

### DIFF
--- a/src/main/java/com/mysite/notificationservice/domain/notification/subscriber/NotificationSubscriber.java
+++ b/src/main/java/com/mysite/notificationservice/domain/notification/subscriber/NotificationSubscriber.java
@@ -1,0 +1,57 @@
+package com.mysite.notificationservice.domain.notification.subscriber;
+
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.mysite.notificationservice.domain.sse.SseEmitterManager;
+
+/**
+ * PackageName : com.mysite.notificationservice.domain.notification.subscriber
+ * FileName    : NotificationSubscriber
+ * Author      : hc
+ * Date        : 25. 4. 28.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 25. 4. 28.     hc               Initial creation
+ */
+@Component
+public class NotificationSubscriber implements MessageListener {
+
+	private final SseEmitterManager sseEmitterManager;
+
+	@Autowired
+	public NotificationSubscriber(SseEmitterManager sseEmitterManager) {
+		this.sseEmitterManager = sseEmitterManager;
+	}
+
+	@Override
+	public void onMessage(Message message, byte[] pattern) {
+		String payload = new String(message.getBody());
+
+		// payload = "userId|message" 형태로 되어있다고 가정
+		String[] parts = payload.split("\\|", 2);
+		if (parts.length != 2) {
+			return; // 잘못된 포맷이면 무시
+		}
+
+		String userId = parts[0];
+		String notificationMessage = parts[1];
+
+		SseEmitter emitter = sseEmitterManager.getEmitter(userId);
+		if (emitter != null) {
+			try {
+				emitter.send(notificationMessage);
+			} catch (IOException e) {
+				emitter.completeWithError(e);
+				sseEmitterManager.removeEmitter(userId);
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
Closes #5 

  <br/>

## 🔎 작업 내용
- Redis에서 알림 메시지를 수신하여 특정 사용자에게 SSE로 전송하는 NotificationSubscriber 구현
- Redis 메시지 포맷 "userId|message"를 파싱하여 해당 사용자의 SseEmitter로 알림 전송
- 포맷이 잘못된 경우 메시지를 무시하도록 처리
- 메시지 전송 실패 시 해당 SseEmitter를 종료하고, 사용자의 emitter 제거
  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>