### PR TITLE
[FEAT] 클라이언트 SSE 연결 API 구현

### DIFF
--- a/src/main/java/com/mysite/notificationservice/domain/sse/SseEmitterManager.java
+++ b/src/main/java/com/mysite/notificationservice/domain/sse/SseEmitterManager.java
@@ -24,7 +24,7 @@ public class SseEmitterManager {
 	private final Map<String, SseEmitter> emitterMap = new ConcurrentHashMap<>();
 
 	// 사용자별 SseEmitter를 추가하는 메서드
-	public SseEmitter createEmitter(String userId) {
+	private SseEmitter createEmitter(String userId) {
 		SseEmitter emitter = new SseEmitter(60_000L);  // 타임아웃 60초
 
 		// 타임아웃이나 연결 종료 시 Emitter 제거
@@ -43,5 +43,10 @@ public class SseEmitterManager {
 	// 사용자별 SseEmitter 가져오기
 	public SseEmitter getEmitter(String userId) {
 		return emitterMap.get(userId);
+	}
+
+	// 클라이언트의 SSE 구독 요청 처리 메서드
+	public SseEmitter subscribe(String userId) {
+		return createEmitter(userId);
 	}
 }

--- a/src/main/java/com/mysite/notificationservice/domain/sse/controller/SseController.java
+++ b/src/main/java/com/mysite/notificationservice/domain/sse/controller/SseController.java
@@ -1,0 +1,36 @@
+package com.mysite.notificationservice.domain.sse.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.mysite.notificationservice.domain.sse.SseEmitterManager;
+
+/**
+ * PackageName : com.mysite.notificationservice.domain.notification.controller
+ * FileName    : SseController
+ * Author      : hc
+ * Date        : 25. 4. 28.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 25. 4. 28.     hc               Initial creation
+ */
+@RestController
+public class SseController {
+
+	private final SseEmitterManager sseEmitterManager;
+
+	@Autowired
+	public SseController(SseEmitterManager sseEmitterManager) {
+		this.sseEmitterManager = sseEmitterManager;
+	}
+
+	@GetMapping("/subscribe/{userId}")
+	public SseEmitter subscribe(@PathVariable String userId) {
+		return sseEmitterManager.subscribe(userId);
+	}
+}


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
Closes #6 
  <br/>

## 🔎 작업 내용
- /subscribe API 생성
- 클라이언트가 연결 요청 시 SseEmitter 반환
- `subscribe` 메서드를 통해 클라이언트의 연결을 처리하고, `SseEmitter`를 반환

  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>