### PR TITLE
[FEAT] : 알림 전송 API 구현

### DIFF
--- a/src/main/java/com/mysite/notificationservice/domain/sse/controller/SseController.java
+++ b/src/main/java/com/mysite/notificationservice/domain/sse/controller/SseController.java
@@ -1,12 +1,20 @@
 package com.mysite.notificationservice.domain.sse.controller;
 
+import java.io.IOException;
+import java.util.Map;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.mysite.notificationservice.domain.sse.SseEmitterManager;
+import com.mysite.notificationservice.domain.sse.controller.dto.NotificationRequest;
 
 /**
  * PackageName : com.mysite.notificationservice.domain.notification.controller
@@ -32,5 +40,21 @@ public class SseController {
 	@GetMapping("/subscribe/{userId}")
 	public SseEmitter subscribe(@PathVariable String userId) {
 		return sseEmitterManager.subscribe(userId);
+	}
+
+	@PostMapping(value = "/send")
+	public ResponseEntity<Map<String, Object>> sendNotification(@RequestBody NotificationRequest request) {
+		SseEmitter emitter = sseEmitterManager.getEmitter(request.userId());
+		if (emitter != null) {
+			try {
+				emitter.send(request.message());
+				return ResponseEntity.ok(Map.of("result", "알림이 성공적으로 전송되었습니다."));
+			} catch (IOException e) {
+				return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+					.body(Map.of("result", "알림 전송 중 오류가 발생했습니다."));
+			}
+		} else {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("result", "유저 ID에 해당하는 구독자가 없습니다."));
+		}
 	}
 }

--- a/src/main/java/com/mysite/notificationservice/domain/sse/controller/dto/NotificationRequest.java
+++ b/src/main/java/com/mysite/notificationservice/domain/sse/controller/dto/NotificationRequest.java
@@ -1,0 +1,18 @@
+package com.mysite.notificationservice.domain.sse.controller.dto;
+
+/**
+ * PackageName : com.mysite.notificationservice.domain.sse.controller.dto
+ * FileName    : NotificationRequest
+ * Author      : hc
+ * Date        : 25. 4. 28.
+ * Description : 
+ * =====================================================================================================================
+ * DATE          AUTHOR               NOTE
+ * ---------------------------------------------------------------------------------------------------------------------
+ * 25. 4. 28.     hc               Initial creation
+ */
+public record NotificationRequest(
+	String userId,
+	String message
+) {
+}

--- a/src/test/java/com/mysite/notificationservice/domain/sse/controller/SseControllerTest.java
+++ b/src/test/java/com/mysite/notificationservice/domain/sse/controller/SseControllerTest.java
@@ -1,0 +1,96 @@
+package com.mysite.notificationservice.domain.sse.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import com.mysite.notificationservice.domain.sse.SseEmitterManager;
+import com.mysite.notificationservice.domain.sse.controller.dto.NotificationRequest;
+
+@ExtendWith(MockitoExtension.class)
+public class SseControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Mock
+	private SseEmitterManager sseEmitterManager;
+
+	@InjectMocks
+	private SseController sseController;
+
+	@BeforeEach
+	void setUp() {
+		mockMvc = MockMvcBuilders.standaloneSetup(sseController)
+			.defaultRequest(post("/send")
+				.contentType(MediaType.APPLICATION_JSON) // 모든 요청의 Content-Type을 application/json으로 설정
+				.characterEncoding("UTF-8")) // UTF-8 인코딩 설정
+			.build();
+	}
+
+	@Test
+	@DisplayName("알림 전송 성공")
+	void t1() throws Exception {
+		String userId = "user123";
+		String message = "Test Notification";
+		NotificationRequest request = new NotificationRequest(userId, message);
+
+		when(sseEmitterManager.getEmitter(userId)).thenReturn(new SseEmitter());
+
+		ResultActions perform = mockMvc.perform(post("/send")
+			.content("{\"userId\":\"user123\", \"message\":\"Test Notification\"}"));
+
+		perform.andExpect(status().isOk())
+			.andExpect(jsonPath("$.result").value("알림이 성공적으로 전송되었습니다."));
+	}
+
+	@Test
+	@DisplayName("알림 전송 실패 - 구독자 없음")
+	void t2() throws Exception {
+		String userId = "user123";
+		String message = "Test Notification";
+		NotificationRequest request = new NotificationRequest(userId, message);
+
+		when(sseEmitterManager.getEmitter(userId)).thenReturn(null);
+
+		mockMvc.perform(post("/send")
+				.content("{\"userId\":\"user123\", \"message\":\"Test Notification\"}"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.result").value("유저 ID에 해당하는 구독자가 없습니다."));
+	}
+
+	@Test
+	@DisplayName("알림 전송 실패 - IOException 발생")
+	void t3() throws Exception {
+		String userId = "user123";
+		String message = "Test Notification";
+		NotificationRequest request = new NotificationRequest(userId, message);
+
+		SseEmitter emitter = mock(SseEmitter.class);
+		when(sseEmitterManager.getEmitter(userId)).thenReturn(emitter);
+
+		doThrow(new IOException("Test exception"))
+			.when(emitter)
+			.send(message);
+
+		mockMvc.perform(post("/send")
+				.content("{\"userId\":\"user123\", \"message\":\"Test Notification\"}"))
+			.andExpect(status().isInternalServerError())
+			.andExpect(jsonPath("$.result").value("알림 전송 중 오류가 발생했습니다."));
+	}
+}
+


### PR DESCRIPTION
<!-- 제목작성 요령 -->
<!-- [${convention}] : ${구현 내용} -->
<!-- [FEAT] : 회원 가입 구현 -->

## 📝Part
- [x] BE
- [ ] FE
- [ ] Infra

  <br/>

## #️⃣연관된 이슈
<!-- #{Issue번호} + Enter -->
<!-- ex) #17 -->
<!-- 이슈와 PR 연결을 위해 사용합니다!-->
Closes #7 
  <br/>

## 🔎 작업 내용
- /send 엔드포인트를 통해 알림 전송 기능 구현
- SseEmitter를 사용하여 구독자에게 알림을 전송
- 구독자가 없거나 IO 예외가 발생하는 경우에 대한 예외 처리 추가
- api 컨트롤러 테스트 구현
  <br/>

## 💬 집중 리뷰 요구
<!-- 리뷰어에게 특별히 봐주었으면하는 리뷰가 있다면 적어주세요. -->

  <br/>

## 📈이미지 첨부 (필요시)
  <br/>